### PR TITLE
add l2m4m dep & mathml support

### DIFF
--- a/main/denylist.py
+++ b/main/denylist.py
@@ -154,6 +154,43 @@ ALLOWED_HTML_ELEMENTS = [
     "wbr",
 ]
 
+# see https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element
+mathml_elements = [
+    "math",
+    # "maction", # depracated
+    "annotation",
+    "annotation-xml",
+    # "memclose", # non-standard
+    "merror",
+    # "mfenced", # depracated
+    "mfrac",
+    "mi",
+    "mmultiscripts",
+    "mn",
+    "mo",
+    "mover",
+    "mpadded",
+    "mphantom",
+    "mprescript",
+    "mroot",
+    "mrow",
+    "ms",
+    "semantics",
+    "mspace",
+    "msqrt",
+    "mstyle",
+    "msub",
+    "msup",
+    "msubsup",
+    "mtable",
+    "mtd",
+    "mtext",
+    "mtr",
+    "munder",
+    "munderover",
+]
+ALLOWED_HTML_ELEMENTS += mathml_elements
+
 # attributes allowed to exist inside the elements of the HTML of a markdown text
 ALLOWED_HTML_ATTRS = [
     "align",
@@ -177,6 +214,78 @@ ALLOWED_HTML_ATTRS = [
     "title",
     "width",
 ]
+
+# https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Attribute
+# unsure if these are required for mathml to work? we could ask the `latex2mathml` project what attributes they use.
+mathml_attrs = [
+    # ### global attributes -> there are more see https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Global_attributes
+    "displaystyle",
+    "mathbackground",
+    "mathcolor",
+    "mathsize",
+    "scriptlevel",
+    # ### non-global
+    "accent",
+    "accentunder",
+    # "actiontype", # depracated
+    "align",
+    # "background", # depracated
+    # "close", # depracated
+    # "color", # depracated
+    "columnalign",
+    "columnlines",
+    "columnspacing",
+    "columnspan",
+    # "denomalign", # depracated
+    "depth",
+    "dir",
+    "display",
+    "displaystyle",
+    "fence",
+    # "fontfamily", # depracated
+    # "fontsize", # depracated
+    # "fontstyle", # depracated
+    # "fontweight", # depracated
+    "frame",
+    "framespacing",
+    "height",
+    "href",
+    "id",
+    "linethickness",
+    "lspace",
+    "lspace",
+    # "lquote", # depracated
+    "mathbackground",
+    "mathcolor",
+    "mathsize",
+    "mathvariant",
+    "maxsize",
+    "minsize",
+    "movablelimits",
+    "notation",
+    # "numalign", # depracated
+    # "open", # depracated
+    "rowalign",
+    "rowlines",
+    "rowspacing",
+    "rowspan",
+    "rspace",
+    # "rspace", # depracated
+    "scriptlevel",
+    # "scriptminsize", # depracated
+    # "scriptsizemultiplier", # depracated
+    # "selection", # depracated
+    "separator",
+    # "separators", # depracated
+    "stretchy",
+    # "subscriptshift", # depracated
+    # "superscriptshift", # depracated
+    "symmetric",
+    "voffset",
+    "width",
+    "xmlns",
+]
+ALLOWED_HTML_ATTRS += mathml_attrs
 
 # css rules allowed to exist as inline styles on HTML elements of a markdown text
 ALLOWED_CSS_STYLES = [

--- a/main/util.py
+++ b/main/util.py
@@ -11,6 +11,7 @@ from django.conf import settings
 from django.utils.text import slugify
 from pygments.formatters import HtmlFormatter
 from pygments.lexers import ClassNotFound, get_lexer_by_name, get_lexer_for_filename
+from l2m4m import LaTeX2MathMLExtension
 
 from main import denylist, models
 
@@ -148,6 +149,7 @@ def md_to_html(markdown_string, strip_tags=False):
             "markdown.extensions.tables",
             "markdown.extensions.footnotes",
             "markdown.extensions.toc",
+            LaTeX2MathMLExtension(),
         ],
     )
     return clean_html(dirty_html, strip_tags)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "bleach[css]>=6.2.0",
     "django>=5.2.5",
     "gunicorn>=23.0.0",
+    "l2m4m>=1.0.4",
     "markdown>=3.8.2",
     "psycopg[binary]>=3.2.9",
     "pygments>=2.19.2",

--- a/uv.lock
+++ b/uv.lock
@@ -273,6 +273,28 @@ wheels = [
 ]
 
 [[package]]
+name = "l2m4m"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "latex2mathml" },
+    { name = "markdown" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/71/2548c288ef1b27f3419285e45430b8f10b9be8f4c34b4d2ecec2d34baf42/l2m4m-1.0.4.tar.gz", hash = "sha256:7fc451edb281604c1eb9d6fa626a8cce874e8a0d3641cca581c20b7544f51396", size = 16567, upload-time = "2024-06-15T16:49:04.798Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/8a/500639fe4b0b1dfc7775633b9173d96a474bbc0811578e916595c9b323f0/L2M4M-1.0.4-py3-none-any.whl", hash = "sha256:766e232b28cfdc6397e9c47162a938dba26e5ab90bddec8d82eccb7896ab46d1", size = 14985, upload-time = "2024-06-15T16:49:03.88Z" },
+]
+
+[[package]]
+name = "latex2mathml"
+version = "3.78.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/26/57b1034c08922d0aefea79430a5e0006ffaee4f0ec59d566613f667ab2f7/latex2mathml-3.78.1.tar.gz", hash = "sha256:f941db80bf41db33f31df87b304e8b588f8166b813b0257c11c98f7a9d0aac71", size = 74030, upload-time = "2025-08-29T23:34:23.178Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/76/d661ea2e529c3d464f9efd73f9ac31626b45279eb4306e684054ea20e3d4/latex2mathml-3.78.1-py3-none-any.whl", hash = "sha256:f089b6d75e85b937f99693c93e8c16c0804008672c3dd2a3d25affd36f238100", size = 73892, upload-time = "2025-08-29T23:34:21.98Z" },
+]
+
+[[package]]
 name = "markdown"
 version = "3.8.2"
 source = { registry = "https://pypi.org/simple" }
@@ -317,6 +339,7 @@ dependencies = [
     { name = "bleach", extra = ["css"] },
     { name = "django" },
     { name = "gunicorn" },
+    { name = "l2m4m" },
     { name = "markdown" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pygments" },
@@ -336,6 +359,7 @@ requires-dist = [
     { name = "bleach", extras = ["css"], specifier = ">=6.2.0" },
     { name = "django", specifier = ">=5.2.5" },
     { name = "gunicorn", specifier = ">=23.0.0" },
+    { name = "l2m4m", specifier = ">=1.0.4" },
     { name = "markdown", specifier = ">=3.8.2" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.9" },
     { name = "pygments", specifier = ">=2.19.2" },


### PR DESCRIPTION
#14

- Added l2m4m dependency
   - Believe this is an acceptable dependency, it isn't much code wrapping the latex2mathml package.
- mathml has a bunch of html elements it uses (within a <math> el).
   - Added most of these to the denylist file (and some attributes). May require a further review.
- Tested a few 'improper' equation blocks, and it doesn't crash anything (just passes $-blocks etc. through as text)

```
Now. can use latex equations inline $v_x$, or as blocks:

$$T = \frac{1}{2}v_x^2$$

Piecewise function:

$$ f(x) = \left\{ \begin{array} {rcl} 
-1 & : & x<0 \\
0 & : & x=0 \\
+1 & : & x>0
\end{array} \right\} $$

Sum & limit:

$$ e^x
= \sum_{n=0}^\infty \frac{x^n}{n!}
= \lim_{n\to\infty} \left( 1+ \frac{x}{n} \right)^n $$
```
